### PR TITLE
Pc make main default branch for ci

### DIFF
--- a/.github/workflows/frontend-coverage.yml
+++ b/.github/workflows/frontend-coverage.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   build:

--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   build:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   build:

--- a/docs/github-actions-secrets.md
+++ b/docs/github-actions-secrets.md
@@ -40,7 +40,19 @@ To get started, you'll need to do two things first:
   for CS156, you should see the name of that organization (e.g. `ucsb-cs156-f20`)Note that the quarter may be different depending on when you are reading these
   instructions--navigate to the organization for the current quarter.
   
-  You should then be able to navigate to your own repo, and get to a page that has, across the top, tabs such as these:
+
+  You should then be able to navigate to a link for your own repo.
+  
+  If you do NOT see your organization or repo, you can also try just 
+  putting in a URL directly that has the following form, replacing `ORG-NAME`
+  with the name of your class organization e.g. `ucsb-cs156-f20` and
+  `REPO-NAME` with the name of your repo.
+
+  ```
+  https://codecov.io/gh/ORG-NAME/REPO-NAME
+  ```
+
+  That should take you to a page that has, across the top, tabs such as these:
 
   | Overview | Commits | Branches | Pulls | Compares | Settings
 


### PR DESCRIPTION
In this PR, we make `main` the branch for CI.   (This code was originally developed in a legacy repo that had `master` as the main branch.

Also, add instructions to clarify that the URL for codecov can be guessed if the navigation is not working properly (there are sometimes caching and timing issues with the codecov web ui showing all orgs and repos.)