### PR TITLE
Sc toggle todo bug

### DIFF
--- a/javascript/src/main/pages/Todos/Todos.js
+++ b/javascript/src/main/pages/Todos/Todos.js
@@ -7,6 +7,7 @@ import { TodoHeader } from "./TodoHeader";
 import { fetchWithToken } from "main/utils/fetch";
 import { useAuth0 } from "@auth0/auth0-react";
 import Loading from "main/components/Loading/Loading";
+import { sortTodos } from "../../utils/todoHelpers";
 
 const TodoList = () => {
   const { user, getAccessTokenSilently: getToken } = useAuth0();
@@ -56,8 +57,7 @@ const TodoList = () => {
     });
     await mutateTodos();
   };
-  var items = todoList.map((item, index) => {
-    console.log(item);
+  var items = sortTodos(todoList).map((item, index) => {
     return (
       <TodoItem
         key={index}

--- a/javascript/src/main/pages/Todos/Todos.js
+++ b/javascript/src/main/pages/Todos/Todos.js
@@ -57,6 +57,7 @@ const TodoList = () => {
     await mutateTodos();
   };
   var items = todoList.map((item, index) => {
+    console.log(item);
     return (
       <TodoItem
         key={index}

--- a/javascript/src/main/utils/todoHelpers.js
+++ b/javascript/src/main/utils/todoHelpers.js
@@ -1,0 +1,7 @@
+export const sortTodos = (todos) => {
+  return todos.sort((todoOne, todoTwo) => {
+    if (todoOne.done !== todoTwo.done)
+      return todoOne.done - todoTwo.done;
+    return todoOne.value.localeCompare(todoTwo.value);
+  });
+}

--- a/javascript/src/test/utils/todoHelpers.test.js
+++ b/javascript/src/test/utils/todoHelpers.test.js
@@ -1,0 +1,43 @@
+import { sortTodos } from "main/utils/todoHelpers";
+
+describe("todo helper tests", () => {
+  test("sortTodo sorts todos by completion status then by value", () => {
+    const initialOrder = [
+      {
+        value: "a",
+        done: true,
+      },
+      {
+        value: "b",
+        done: false,
+      },
+      {
+        value: "b",
+        done: true,
+      },
+      {
+        value: "a",
+        done: false,
+      },
+    ];
+    const expectedOrder = [
+      {
+        value: "a",
+        done: false,
+      },
+      {
+        value: "b",
+        done: false,
+      },
+      {
+        value: "a",
+        done: true,
+      },
+      {
+        value: "b",
+        done: true,
+      },
+    ];
+    expect(sortTodos(initialOrder)).toEqual(expectedOrder);
+  });
+});


### PR DESCRIPTION
Resolves #16.

This PR introduces an arbitrary sorting of todos in order to fix a bug in deployments where todos might appear out of order when completed or deleted. In reality, the component was failing to re-render. Sorting the todos prevents this ordering bug from occurring.