### PR TITLE
Implement logged in text with profile image

### DIFF
--- a/javascript/src/main/components/Nav/AuthNav.js
+++ b/javascript/src/main/components/Nav/AuthNav.js
@@ -7,7 +7,7 @@ import LogoutButton from "./LogoutButton";
 const AuthNav = () => {
   const { user } = useAuth0();
   if(user) {
-    const { name, picture, email } = user;
+    const { name, picture } = user;
     return <>
       <Navbar.Text style={{marginRight: 15}}>{"Hello, " + name}</Navbar.Text>  
       <img

--- a/javascript/src/main/components/Nav/AuthNav.js
+++ b/javascript/src/main/components/Nav/AuthNav.js
@@ -8,16 +8,19 @@ const AuthNav = () => {
   const { user } = useAuth0();
   if(user) {
     const { name, picture, email } = user;
-    return <><Navbar.Text style={{marginRight: 15}}>{"Hello, " + name}
-      </Navbar.Text>      <img
+    return <>
+      <Navbar.Text style={{marginRight: 15}}>{"Hello, " + name}</Navbar.Text>  
+      <img
             src={picture}
             alt="Profile"
             className="rounded-circle"
             width="36"
             style={{marginRight: 15}}
-      /><LogoutButton /></>
+      />
+      <LogoutButton />
+    </>
   } else {
-    return <><LoginButton/></>
+    return <LoginButton/>
   }
 };
 

--- a/javascript/src/main/components/Nav/AuthNav.js
+++ b/javascript/src/main/components/Nav/AuthNav.js
@@ -1,11 +1,24 @@
 import React from "react";
 import { useAuth0 } from "@auth0/auth0-react";
+import { Navbar } from "react-bootstrap";
 import LoginButton from "./LoginButton";
 import LogoutButton from "./LogoutButton";
 
 const AuthNav = () => {
-  const { isAuthenticated } = useAuth0();
-  return <>{isAuthenticated ? <LogoutButton /> : <LoginButton />}</>;
+  const { user } = useAuth0();
+  if(user) {
+    const { name, picture, email } = user;
+    return <><Navbar.Text style={{marginRight: 15}}>{"Hello, " + name}
+      </Navbar.Text>      <img
+            src={picture}
+            alt="Profile"
+            className="rounded-circle"
+            width="36"
+            style={{marginRight: 15}}
+      /><LogoutButton /></>
+  } else {
+    return <><LoginButton/></>
+  }
 };
 
 export default AuthNav;

--- a/javascript/src/test/components/Nav/AuthNav.test.js
+++ b/javascript/src/test/components/Nav/AuthNav.test.js
@@ -4,6 +4,11 @@ import AuthNav from "main/components/Nav/AuthNav";
 import { useAuth0 } from "@auth0/auth0-react";
 jest.mock("@auth0/auth0-react");
 describe("AuthNav tests", () => {
+  const user = {
+    name: "Test",
+    picture: "http://placekitten.com/200/300"
+  }
+
   beforeEach(() => {
     useAuth0.mockReturnValue({
       isAuthenticated: true,
@@ -24,7 +29,7 @@ describe("AuthNav tests", () => {
 
   test("it renders a logout button when logged out", () => {
     useAuth0.mockReturnValueOnce({
-      user: true,
+      user
     });
     const { getByText } = render(<AuthNav />);
     const loginButton = getByText(/Log Out/);
@@ -32,10 +37,7 @@ describe("AuthNav tests", () => {
   });
 
   test("it renders a welcome message and profile picture when logged in", () => {
-    const user = {
-      name: "Test",
-      picture: "http://placekitten.com/200/300"
-    }
+
     useAuth0.mockReturnValueOnce({
       user
     });

--- a/javascript/src/test/components/Nav/AuthNav.test.js
+++ b/javascript/src/test/components/Nav/AuthNav.test.js
@@ -24,7 +24,7 @@ describe("AuthNav tests", () => {
 
   test("it renders a logout button when logged out", () => {
     useAuth0.mockReturnValueOnce({
-      isAuthenticated: true,
+      user: true,
     });
     const { getByText } = render(<AuthNav />);
     const loginButton = getByText(/Log Out/);

--- a/javascript/src/test/components/Nav/AuthNav.test.js
+++ b/javascript/src/test/components/Nav/AuthNav.test.js
@@ -30,4 +30,19 @@ describe("AuthNav tests", () => {
     const loginButton = getByText(/Log Out/);
     expect(loginButton).toBeInTheDocument();
   });
+
+  test("it renders a welcome message and profile picture when logged in", () => {
+    const user = {
+      name: "Test",
+      picture: "http://placekitten.com/200/300"
+    }
+    useAuth0.mockReturnValueOnce({
+      user
+    });
+    const { getByText, getByAltText } = render(<AuthNav />);
+    const welcomeText = getByText("Hello, " + user.name);
+    expect(welcomeText).toBeInTheDocument();
+    const profileImage = getByAltText("Profile");
+    expect(profileImage).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Resolves #8 

As a user, after I log into the application, I should be able to see a prompt with "Hello, My Name" where "My Name" represents the full name of the account I logged in with to the left of the logout button along with my account picture so that I can tell what account I am logged in with. If I log out, I should not see any prompt to the left of the Login button.

- [x] A welcome prompt, along with a thumbnail profile image, now appears to the left of the Log Out button when the user is logged in. If the user is not logged in, neither are visible.