### PR TITLE
sc - move Todo class + tests into an entity folder, updated imports too

### DIFF
--- a/src/main/java/com/ucsb/demonextjsspringtodoapp/controllers/TodoController.java
+++ b/src/main/java/com/ucsb/demonextjsspringtodoapp/controllers/TodoController.java
@@ -20,7 +20,7 @@ import com.auth0.jwt.JWT;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.ucsb.demonextjsspringtodoapp.models.Todo;
+import com.ucsb.demonextjsspringtodoapp.entities.Todo;
 import com.ucsb.demonextjsspringtodoapp.repositories.TodoRepository;
 
 @RestController

--- a/src/main/java/com/ucsb/demonextjsspringtodoapp/entities/Todo.java
+++ b/src/main/java/com/ucsb/demonextjsspringtodoapp/entities/Todo.java
@@ -1,4 +1,4 @@
-package com.ucsb.demonextjsspringtodoapp.models;
+package com.ucsb.demonextjsspringtodoapp.entities;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;

--- a/src/main/java/com/ucsb/demonextjsspringtodoapp/repositories/TodoRepository.java
+++ b/src/main/java/com/ucsb/demonextjsspringtodoapp/repositories/TodoRepository.java
@@ -2,7 +2,7 @@ package com.ucsb.demonextjsspringtodoapp.repositories;
 
 import java.util.List;
 
-import com.ucsb.demonextjsspringtodoapp.models.Todo;
+import com.ucsb.demonextjsspringtodoapp.entities.Todo;
 
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;

--- a/src/test/java/com/ucsb/demonextjsspringtodoapp/controllers/TodoControllerTests.java
+++ b/src/test/java/com/ucsb/demonextjsspringtodoapp/controllers/TodoControllerTests.java
@@ -26,7 +26,7 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.ucsb.demonextjsspringtodoapp.models.Todo;
+import com.ucsb.demonextjsspringtodoapp.entities.Todo;
 import com.ucsb.demonextjsspringtodoapp.repositories.TodoRepository;
 
 @WebMvcTest(value = TodoController.class)

--- a/src/test/java/com/ucsb/demonextjsspringtodoapp/entities/TodoTests.java
+++ b/src/test/java/com/ucsb/demonextjsspringtodoapp/entities/TodoTests.java
@@ -1,4 +1,4 @@
-package com.ucsb.demonextjsspringtodoapp.models;
+package com.ucsb.demonextjsspringtodoapp.entities;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;


### PR DESCRIPTION
Resolves #33 by moving the `Todo` entity + tests into an `entities` folder.