### PR TITLE
pc - to fix #55, exclude  to avoid multiple definitions of

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,10 @@
 					<groupId>org.junit.vintage</groupId>
 					<artifactId>junit-vintage-engine</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>com.vaadin.external.google</groupId>
+					<artifactId>android-json</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Fixes #55 

STR:  Run `mvn test`

Observed: This warning:

```
Found multiple occurrences of org.json.JSONObject on the class path:

jar:file:/Users/pconrad/.m2/repository/com/vaadin/external/google/android-json/0.0.20131108.vaadin1/android-json-0.0.20131108.vaadin1.jar!/org/json/JSONObject.class
	jar:file:/Users/pconrad/.m2/repository/org/json/json/20190722/json-20190722.jar!/org/json/JSONObject.class

You may wish to exclude one of them to ensure predictable runtime behavior
```

Desired: No warning of this type.

Implemented fix: See: https://stackoverflow.com/a/52980523

