### PR TITLE
pc - change test examples to be something more neutral

### DIFF
--- a/javascript/src/test/pages/Admin/Admin.test.js
+++ b/javascript/src/test/pages/Admin/Admin.test.js
@@ -13,12 +13,12 @@ describe("Admin tests", () => {
   const admins = [
     {
       id: 2,
-      email: "biden@usa.gov",
+      email: "cgaucho@example.org",
       isPermanentAdmin: true
     },
     {
       id: 3,
-      email: "kamala@usa.gov",
+      email: "ldelplaya@example.org",
       isPermanentAdmin: false
     },
   ];
@@ -31,15 +31,15 @@ describe("Admin tests", () => {
     },
     {
       id: 2,
-      email: "biden@usa.gov",
-      firstName: "Joe",
-      lastName: "Biden"
+      email: "cgaucho@example.org",
+      firstName: "Chris",
+      lastName: "Gaucho"
     },
     {
       id: 3,
-      email: "kamala@usa.gov",
-      firstName: "Kamala",
-      lastName: "Harris"
+      email: "ldelplaya@example.org",
+      firstName: "Laurie",
+      lastName: "del Playa"
     },
   ];
   const mutateSpy = jest.fn();


### PR DESCRIPTION
This PR is a small change to `sc-promotionDemotion` to make the test case examples more "neutral".